### PR TITLE
Default embeddingNodeProperty value

### DIFF
--- a/libs/langchain-community/src/vectorstores/neo4j_vector.ts
+++ b/libs/langchain-community/src/vectorstores/neo4j_vector.ts
@@ -36,6 +36,7 @@ interface Neo4jVectorStoreArgs {
 const DEFAULT_SEARCH_TYPE = "vector";
 const DEFAULT_INDEX_TYPE = "NODE";
 const DEFAULT_DISTANCE_STRATEGY = "cosine";
+const DEFAULT_NODE_EMBEDDING_PROPERTY = "embedding";
 
 /**
  * @security *Security note*: Make sure that the database connection uses credentials
@@ -102,7 +103,7 @@ export class Neo4jVectorStore extends VectorStore {
       preDeleteCollection = false,
       nodeLabel = "Chunk",
       textNodeProperty = "text",
-      embeddingNodeProperty = "embedding",
+      embeddingNodeProperty = DEFAULT_NODE_EMBEDDING_PROPERTY,
       keywordIndexName = "keyword",
       indexName = "vector",
       retrievalQuery = "",
@@ -333,7 +334,7 @@ export class Neo4jVectorStore extends VectorStore {
   ) {
     const {
       textNodeProperties = [],
-      embeddingNodeProperty,
+      embeddingNodeProperty = DEFAULT_NODE_EMBEDDING_PROPERTY,
       searchType = DEFAULT_SEARCH_TYPE,
       retrievalQuery = "",
       nodeLabel,
@@ -346,6 +347,7 @@ export class Neo4jVectorStore extends VectorStore {
         "Parameter `text_node_properties` must not be an empty array"
       );
     }
+
 
     if (!retrievalQuery) {
       _retrievalQuery = `


### PR DESCRIPTION
If the `embeddingNodeProperty` is not set in he config when calling `Neo4jVectorStore.fromExistingGraph()`, the property will be named `undefined`.

<!--
Thank you for contributing to LangChain.js! Your PR will appear in our next release under the title you set above. Please make sure it highlights your valuable contribution.

To help streamline the review process, please make sure you read our contribution guidelines:
https://github.com/langchain-ai/langchainjs/blob/main/CONTRIBUTING.md

If you are adding an integration (e.g. a new LLM, vector store, or memory), please also read our additional guidelines for integrations:
https://github.com/langchain-ai/langchainjs/blob/main/.github/contributing/INTEGRATIONS.md

Replace this block with a description of the change, the issue it fixes (if applicable), and relevant context.

Finally, we'd love to show appreciation for your contribution - if you'd like us to shout you out on Twitter, please also include your handle below!
-->

<!-- Remove if not applicable -->

